### PR TITLE
docs: Add faq to README of how to across-compile from linux to windows 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ go install github.com/sipkg/pdf2jpg
 ```sh
 pdf2jpg -out test%03d.jpg -qual 1 -in test.pdf
 ```
+
+## FAQ
+
+### How to across-compile from linux to windows
+
+Because go-fitz library uses https://golang.org/cmd/cgo/, so you need to have compiler and toolchain for arch you want to build for, and also, enable `CGO_ENABLED=1`. 
+
+1. `sudo apt-get install mingw-w64`
+1. `GOOS="windows" GOARCH="amd64" CGO_ENABLED="1" CC="x86_64-w64-mingw32-gcc" go build`


### PR DESCRIPTION
Because go-fitz library uses https://golang.org/cmd/cgo/, so you need to have compiler and toolchain for arch you want to build for, and also, enable `CGO_ENABLED=1`. 